### PR TITLE
fix: correction to hide enviroment variables of jwt

### DIFF
--- a/src/config/jwt/config.jwt.ts
+++ b/src/config/jwt/config.jwt.ts
@@ -1,2 +1,2 @@
-export const secret = '3f9b2e1933c44582d12641b663eca4c5';
-export const expiresIn = '7d';
+export const secret = process.env.JWT_SECRET_KEY;
+export const expiresIn = process.env.JWT_EXPIRES_IN;


### PR DESCRIPTION
What was done:

- [x] Hidden jwt environment variables

closes #6 

